### PR TITLE
Handle special case for 500s

### DIFF
--- a/History.md
+++ b/History.md
@@ -17,3 +17,8 @@
 ==================
 
   * Allow Guzzle options to be passed per request.
+
+0.0.10 / 2017-09-27
+==================
+
+  * Handle 500 errors more gracefully.

--- a/Koko/Tracker.php
+++ b/Koko/Tracker.php
@@ -23,10 +23,14 @@ class Tracker {
     $request_options_copy['json'] = $options;
 
     $response = $this->client->request('POST', $url, $request_options_copy);
+    $contents = $response->getBody()->getContents();
 
-    $json = $response->getBody()->getContents();
-    $data = json_decode($json, true);
+    $status = $response->getStatusCode();
+    if ($status >= 500) {
+      throw new \Exception($contents);
+    }
 
+    $data = json_decode($contents, true);
     if (array_key_exists('errors', $data)) {
       throw new \Exception(join('\n', $data['errors']));
     }


### PR DESCRIPTION
Since 500s are returned upstream from the API, they are not necessarily JSON and need to be special-cased. With this fix, the response content is used as the exception message for 500x errors, instead of being parsed from a JSON response. 