### PR TITLE
Handle getting a null response from the server

### DIFF
--- a/Koko/Tracker.php
+++ b/Koko/Tracker.php
@@ -31,6 +31,10 @@ class Tracker {
     }
 
     $data = json_decode($contents, true);
+    if (!is_array($data)) {
+        throw new \Exception('No response data returned.');
+    }
+
     if (array_key_exists('errors', $data)) {
       throw new \Exception(join('\n', $data['errors']));
     }


### PR DESCRIPTION
## Summary

When getting back no data from the server, the `array_key_exists()` check raises the PHP error `array_key_exists() expects parameter 2 to be array, null given on line 1`. Since we don't suppress PHP errors in production, any malformed data returned from the server would flood our monitoring.

Here I'm adding an explicit check to make sure the data returned from the server is an array before doing any other processing.